### PR TITLE
fixed issue #1: add missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "react-router": "3.2.0",
     "rsuite": "^3.2.2",
     "rsuite-utils": "^1.0.0"
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.1"
   },
   "peerDependencies": {
     "react": "^0.14.9 || >=15.3.0",


### PR DESCRIPTION
参考https://github.com/plotly/dash-component-boilerplate/issues/12#issuecomment-425040481

> This was broken by a webpack update, see [webpack/webpack#8082](https://github.com/webpack/webpack/issues/8082)
> 
> A workaround for now is to update both, webpack and webpack-cli in package.json:
> 
> ```
>     "webpack": "^4.20.2",
>     "webpack-cli": "^3.1.1",
> ```